### PR TITLE
Temporarily disabled the static IP address part.

### DIFF
--- a/MightyRemote/MightyRemote.ino
+++ b/MightyRemote/MightyRemote.ino
@@ -110,7 +110,8 @@ void setup() {
   loadButtonNamesFromSPIFFS();
 
   // Set static IP configuration
-  wifiManager.setSTAStaticIPConfig(staticIP, gateway, subnet, dns);
+  // commented this for now since there's an issue when connecting to hotspots.
+  // wifiManager.setSTAStaticIPConfig(staticIP, gateway, subnet, dns);
 
    // Connect to Wi-Fi using WiFiManager
   Serial.println("Connecting to WiFi...");


### PR DESCRIPTION
For now use the static IP displayed on the Serial monitor. OR use the mightyremote.local if your device supports mdns